### PR TITLE
rename eastward/northward wind to x/y wind

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 FV3GFS
 ======
 
-
 fv3gfs-python (`import fv3gfs`), is a Python wrapper for the FV3GFS
 global climate model.
-
 
 Checking out
 ------------

--- a/fv3gfs/dynamics_properties.json
+++ b/fv3gfs/dynamics_properties.json
@@ -1,12 +1,12 @@
 [
     {
-        "name": "eastward_wind",
+        "name": "x_wind",
         "fortran_name": "u",
         "units": "m/s",
         "dims": ["z", "y_interface", "x"]
     },
     {
-        "name": "northward_wind",
+        "name": "y_wind",
         "fortran_name": "v",
         "units": "m/s",
         "dims": ["z", "y", "x_interface"]

--- a/tests/test_getters.py
+++ b/tests/test_getters.py
@@ -37,7 +37,7 @@ class GetterTests(unittest.TestCase):
 
     def test_dynamics_quantities_present_in_metadata(self):
         """Test that some small subset of dynamics names are in the data dictionary"""
-        for name in ['eastward_wind', 'northward_wind', 'vertical_wind', 'surface_geopotential']:
+        for name in ['x_wind', 'y_wind', 'vertical_wind', 'surface_geopotential']:
             self.assertIn(name, self.dynamics_data.keys())
 
     def test_physics_quantities_present_in_metadata(self):

--- a/tests/test_setters.py
+++ b/tests/test_setters.py
@@ -38,7 +38,7 @@ class SetterTests(unittest.TestCase):
     def test_dynamics_names_present(self):
         """Test that some small subset of dynamics names are in the data dictionary"""
         for name in [
-                'eastward_wind', 'northward_wind', 'vertical_wind',
+                'x_wind', 'y_wind', 'vertical_wind',
                 'surface_geopotential']:
             self.assertIn(name, self.dynamics_data.keys())
 


### PR DESCRIPTION
eastward_wind and northward_wind are misnomers, since these are actually along the x and y direction of the local tile. This PR renames those to `x_wind` and `y_wind`.