### PR TITLE
push correct image name when on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,6 @@ jobs:
   build_default:
     machine:
       docker_layer_caching: true
-    environment:
-      DOCKER_IMAGE: test-image
-      GCR_IMAGE: us.gcr.io/vcm-ml/fv3gfs-python:latest
     steps:
       - checkout
       - add_ssh_keys:
@@ -23,8 +20,7 @@ jobs:
       - run: |
           if [[ "$CIRCLE_BRANCH" == "master" ]]
           then
-              docker tag $DOCKER_IMAGE $GCR_IMAGE
-              docker push $GCR_IMAGE
+              docker push us.gcr.io/vcm-ml/fv3gfs-python
           fi
 workflows:
   version: 2


### PR DESCRIPTION
Pushing the image broke in the latest PR, couldn't find out until merged to master. This fixes it by removing the `test-image` name entirely and directly creating and pushing the `fv3gfs-python` image instead.