### PR TITLE
Make stacksize unlimited for all bash shells

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -123,5 +123,8 @@ COPY --from=fv3config-inputdata /2019-10-23-data-for-running-fv3gfs /inputdata/f
 
 RUN chmod -R 755 /inputdata
 
+# make stack size unlimited
+RUN echo "ulimit -s unlimited" >> /etc/bash.bashrc
+
 # interactive shell by default
 CMD ["bash"]


### PR DESCRIPTION
The trick was to add the command to `/etc/bash.bashrc` which is loaded for both
"login" and "non-login" shells. Docker run initializes a "non-login" shell.
/etc/profile is only loaded for "login" shells.