### PR TITLE
Include more physics diagnostics in getters/setters

### DIFF
--- a/external/fv3util/fv3util/physics_properties.json
+++ b/external/fv3util/fv3util/physics_properties.json
@@ -1,5 +1,26 @@
 [
     {
+        "name": "mean_cos_zenith_angle",
+        "fortran_name": "coszen",
+        "units": "",
+        "container": "Radtend",
+        "dims": ["y", "x"]
+    },
+    {
+        "name": "sensible_heat_flux",
+        "fortran_name": "dtsfc",
+        "units": "W/m^2",
+        "container": "Intdiag",
+        "dims": ["y", "x"]
+    },
+    {
+        "name": "latent_heat_flux",
+        "fortran_name": "dqsfc",
+        "units": "W/m^2",
+        "container": "Intdiag",
+        "dims": ["y", "x"]
+    },
+    {
         "name": "convective_cloud_fraction",
         "fortran_name": "cv",
         "units": "",


### PR DESCRIPTION
To harmonize the variables available to train an ML scheme with the runtime environment in fv3gfs, this commit add entries for LHF, SHF, and the cosine of the zenith angle to the physics_properties json file. This should make them available to get_state.