### PR TITLE
Reminder to check fv3config is a tagged commit during release

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -3,7 +3,10 @@ Release Instructions
 
 1. Prepare master branch for release (make sure all PRs are merged and tests pass).
 
-2. Run `bumpversion <major/minor/patch>`. This will create a new tagged commit,
+2. Ensure that submodules (e.g. fv3config) point to a tagged commit on master. Tagged
+   versions of fv3gfs-python should depend on tagged versions of dependencies.
+
+2. In the project root, run `bumpversion <major/minor/patch>`. This will create a new tagged commit,
    having updated all version references to the new, higher version.
 
 3. Run `git push && git push origin --tags` to push the version reference commit and


### PR DESCRIPTION
Updated the release instructions to include a step checking that submodules point to tagged versions.