### PR TITLE
Push images for all commits to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,8 +135,6 @@ workflows:
           requires:
             - lint
           filters:
-            branches:
-              only: master
             tags:
               only: /^v.*/
       - docs_deploy:


### PR DESCRIPTION
Building images for every commit to master will allow downstream code
(e.g. fv3net) to more quickly take advantages of contributions to this
repo or its dependencies.

This will also facilitate integration testing multiple repos against
the current master of this image.

This PR tags each image with the SHA of the master commit.