### PR TITLE
Update to latest fv3gfs-fortran and minor fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
           name: "Compile model and perform model tests"
           command: |
             echo "$ENCODED_GCR_KEY" | base64 --decode | docker login --username _json_key --password-stdin https://us.gcr.io
+            DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain BUILD_FROM_INTERMEDIATE=y make -C lib/external pull_deps
             DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain BUILD_FROM_INTERMEDIATE=y make test-docker
       - save_cache:
           paths:

--- a/test_docker.sh
+++ b/test_docker.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 
-set -e
+set -ex
 
-if [ -z "$DOCKER_IMAGE" ]; then
+if [ -z "$DOCKER_IMAGE" ] ; then
     DOCKER_IMAGE=us.gcr.io/vcm-ml/fv3gfs-wrapper:gnu9-mpich314-nocuda
 fi
 
 pytest ./tests/image_tests/*.py
 
-if [[ "GOOGLE_APPLICATION_CREDENTIALS" == "" ]]
-then
-    docker run -it $DOCKER_IMAGE bash -c "cd /fv3gfs-wrapper; make test"
+if [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ] ; then
+    docker run -it "$DOCKER_IMAGE" bash -c "cd /fv3gfs-wrapper; make test"
 else
     docker run -v $GOOGLE_APPLICATION_CREDENTIALS:$GOOGLE_APPLICATION_CREDENTIALS \
         --env GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS \


### PR DESCRIPTION
This PR updates fv3gfs-fortran submodule to the latest master and contains a minor fix in the test_docker.sh script.

@mcgibbon Not sure if this solves the problem you were seeing. All I did is open up a PR with the latest fv3gfs-fortran and things to go smoothly. Not sure where CI was failing before.