### PR TITLE
Allow CC and MPI to be set externally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL = /bin/sh
 
-CC=gcc
-MPI=mpich
+CC ?= gcc
+MPI ?= mpich
 
 .PHONY: build clean clean-test clean-pyc clean-build clean-examples examples lint test coverage docs help docs-docker
 .DEFAULT_GOAL := help

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -9,7 +9,7 @@ PROPERTIES_FILES = ../fv3gfs/wrapper/dynamics_properties.json ../fv3gfs/wrapper/
 FFLAGS += $(shell PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config fv3 --cflags)
 FC ?= mpif90
 
-.PHONY: clean cleanall fortran_libs
+.PHONY: clean cleanall
 
 all: coupler_lib.o dynamics_data.o physics_data.o flagstruct_data.o $(TEMPLATES)
 
@@ -23,7 +23,7 @@ physics_data.o: physics_data.F90 dynamics_data.o
 
 coupler_lib.o: coupler_lib.F90 dynamics_data.o
 
-flagstruct_data.o: flagstruct_data.F90 fortran_libs
+flagstruct_data.o: flagstruct_data.F90
 	$(FC) $(CPPDEFS) $(CPPFLAGS) $(FPPFLAGS) $(FFLAGS) $(OTHERFLAGS) $(OTHER_FFLAGS) $(ESMF_INC) -c $< -o $@
 
 clean:


### PR DESCRIPTION
This PR makes it so you can specify CC and MPI when calling `make build`, which is necessary to get our fv3core-wrapper images to work. It also removes a PHONY target which is undefined and was causing re-compilation to occur when no file changes are made.