### PR TITLE
fix docs going into html subdirectory in gh-pages branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,9 +121,8 @@ jobs:
       - run:
           name: Deploy docs to gh-pages branch
           command: |
-            mkdir upload
+            mv docs/_build/html upload
             touch upload/.nojekyll
-            mv docs/_build/html upload/
             gh-pages --dotfiles --dist upload
 workflows:
   version: 2


### PR DESCRIPTION
Documentation was being put into a subdirectory `html`, this puts the documentation at the root level instead.