### PR TITLE
Remove fv3config submodule and use pip requirement instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,6 @@ jobs:
             pyenv global 3.6.2
             pip install --upgrade pip setuptools
             pip install -r tests/image_tests/requirements.txt
-            pip install --no-deps -e external/fv3config
       - save_cache:
           paths:
             - /opt/circleci/.pyenv/versions/3.6.2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "external/fv3config"]
-	path = external/fv3config
-	url = git@github.com:VulcanClimateModeling/fv3config.git
 [submodule "lib/external"]
 	path = lib/external
 	url = git@github.com:VulcanClimateModeling/fv3gfs-fortran.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ docutils==0.16
 f90nml==1.1.2
 fasteners==0.15
 fsspec==0.8.0
+fv3config==0.5.1
 gcsfs==0.7.0
 google-api-core==1.22.1
 google-auth==1.20.1

--- a/requirements_local.txt
+++ b/requirements_local.txt
@@ -1,3 +1,2 @@
--e external/fv3config
 -e external/fv3gfs-util
 -e .[examples]

--- a/tests/image_tests/requirements.txt
+++ b/tests/image_tests/requirements.txt
@@ -9,6 +9,7 @@ Sphinx==1.8.5
 twine==1.14.0
 Click==7.0
 f90nml>=1.1.0
+fv3config==0.5.1
 appdirs>=1.4.0
 requests
 sphinx_rtd_theme


### PR DESCRIPTION
@nbren12 recently made a pypi deployment of fv3config. Since we haven't updated the version of fv3config we've used in a while, it seems loosely coupled enough to install via pip instead of through a submodule.

This PR updates the repo to use pip and pypi to install fv3config instead of a submodule.