### PR TITLE
Add option to run with physics split into radiation and non-radiation steps

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -47,7 +47,10 @@ in the Fortran model.
     The :py:func:`fv3gfs.wrapper.step_physics` call can be separated into two calls, :py:func:`fv3gfs.wrapper.compute_physics`
     and :py:func:`fv3gfs.wrapper.apply_physics` to allow modification of the model state in between these operations.
     However care should be taken when doing this, because the physics and dynamics states are not
-    consistent with each other before :py:func:`fv3gfs.wrapper.apply_physics` is called.
+    consistent with each other before :py:func:`fv3gfs.wrapper.apply_physics` is called.  For finer granularity still,
+    :py:func:`fv3gfs.wrapper.compute_physics` can be split into two calls, :py:func:`fv3gfs.wrapper.compute_radiation` and
+    :py:func:`fv3gfs.wrapper.compute_non_radiation_physics`, allowing modification of the model state between the radiation
+    and rest of the model physics.
 
 Instead of using a Python script, it is also possible to get precisely the behavior of :code:`fv3.exe` using
 

--- a/fv3gfs/wrapper/__init__.py
+++ b/fv3gfs/wrapper/__init__.py
@@ -12,6 +12,8 @@ from ._wrapper import (
     get_n_ghost_cells,
     get_step_count,
     get_tracer_metadata,
+    compute_radiation,
+    compute_non_radiation_physics,
     compute_physics,
     apply_physics,
     _get_diagnostic_info,

--- a/fv3gfs/wrapper/_run_with_split_physics.py
+++ b/fv3gfs/wrapper/_run_with_split_physics.py
@@ -1,0 +1,22 @@
+"""Mainly for testing purposes.  This reproduces the results of run.py bit-for-bit."""
+from ._wrapper import (
+    initialize,
+    get_step_count,
+    step_dynamics,
+    compute_radiation,
+    compute_non_radiation_physics,
+    apply_physics,
+    save_intermediate_restart_if_enabled,
+    cleanup,
+)
+
+
+if __name__ == "__main__":
+    initialize()
+    for i in range(get_step_count()):
+        step_dynamics()
+        compute_radiation()
+        compute_non_radiation_physics()
+        apply_physics()
+        save_intermediate_restart_if_enabled()
+    cleanup()

--- a/lib/coupler_lib.F90
+++ b/lib/coupler_lib.F90
@@ -20,6 +20,8 @@ use time_manager_mod,  only: time_type, set_calendar_type, set_time,    &
  
 use  atmos_model_mod,  only: atmos_model_init, atmos_model_end,  &
                              update_atmos_model_dynamics,        &
+                             update_atmos_radiation,             &
+                             update_atmos_physics,               &
                              update_atmos_radiation_physics,     &
                              update_atmos_model_state,           &
                              atmos_data_type, atmos_model_restart
@@ -142,6 +144,14 @@ contains
         Time_atmos = Time_atmos + Time_step_atmos
         call update_atmos_model_dynamics (Atm)
     end subroutine do_dynamics
+
+    subroutine compute_atmos_radiation_subroutine() bind(c)
+        call update_atmos_radiation (Atm)
+    end subroutine compute_atmos_radiation_subroutine
+
+    subroutine compute_atmos_physics_subroutine() bind(c)
+        call update_atmos_physics (Atm)
+    end subroutine compute_atmos_physics_subroutine
 
     subroutine compute_physics_subroutine() bind(c)
         call update_atmos_radiation_physics (Atm)

--- a/templates/_wrapper.pyx
+++ b/templates/_wrapper.pyx
@@ -25,6 +25,8 @@ cdef extern:
     void do_step_subroutine()
     void cleanup_subroutine()
     void do_dynamics()
+    void compute_atmos_radiation_subroutine()
+    void compute_atmos_physics_subroutine()
     void compute_physics_subroutine()
     void apply_physics_subroutine()
     void save_intermediate_restart_if_enabled_subroutine()
@@ -402,6 +404,25 @@ def step_physics():
     Equivalent to calling compute_physics() and apply_physics() in that order."""
     compute_physics_subroutine()
     apply_physics_subroutine()
+
+
+def compute_radiation():
+    """Call radiation routines in the Fortran model and update physics prognostic state.
+
+    It is necessary to call both compute_non_radiation_physics() and apply_physics() after
+    this to update the dynamical prognostic state with the output from the routines called
+    by this function.
+    """
+    compute_atmos_radiation_subroutine()
+
+
+def compute_non_radiation_physics():
+    """Call non-radiation subroutines in the Fortran model and update physics prognostic state.
+
+    It is necessary to call apply_physics() after this to update the dynamical prognostic state
+    with output from the routines called by this function.
+    """
+    compute_atmos_physics_subroutine()
 
 
 def compute_physics():


### PR DESCRIPTION
This PR adds two new functions to the wrapper which enable splitting `compute_physics` into two steps, one for radiation, `compute_radiation`, and one for the rest of the physics, `compute_non_radiation_physics`.  I'm open to different names; these were just the first that came to mind.

This PR is tightly coupled to https://github.com/VulcanClimateModeling/fv3gfs-fortran/pull/157; marking this as a draft until that is merged.