### PR TITLE
Fix md5 error on master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ docutils==0.16
 f90nml==1.1.2
 fasteners==0.15
 fsspec==0.8.0
-fv3config==0.5.1
+fv3config==0.7.1
 gcsfs==0.7.0
 google-api-core==1.22.1
 google-auth==1.20.1


### PR DESCRIPTION
Master has been failing for weeks with this error:

    E               NotImplementedError: No md5 checksum available to do consistency check. GCS does not provide md5 sums for composite objects.

This error was unique to the pinned version of fv3config.

Pin to a newer version of fv3config instead.