### PR TITLE
Add test that prescribing SST alters model evolution

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -40,6 +40,9 @@ class UsingMPITests(unittest.TestCase):
     def test_flags(self):
         run_unittest_script("test_flags.py")
 
+    def test_set_ocean_surface_temperature(self):
+        run_unittest_script("test_set_ocean_surface_temperature.py")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_overrides_for_surface_radiative_fluxes.py
+++ b/tests/test_overrides_for_surface_radiative_fluxes.py
@@ -1,12 +1,11 @@
 import unittest
 import os
-from copy import deepcopy
 from fv3gfs.wrapper._properties import OVERRIDES_FOR_SURFACE_RADIATIVE_FLUXES
 import numpy as np
 import fv3gfs.wrapper
 import fv3gfs.util
 from mpi4py import MPI
-from util import get_default_config, main
+from util import get_default_config, main, replace_state_with_random_values
 
 
 test_dir = os.path.dirname(os.path.abspath(__file__))
@@ -15,15 +14,6 @@ test_dir = os.path.dirname(os.path.abspath(__file__))
     DOWNWARD_SHORTWAVE,
     NET_SHORTWAVE,
 ) = OVERRIDES_FOR_SURFACE_RADIATIVE_FLUXES
-
-
-def override_surface_radiative_fluxes_with_random_values():
-    old_state = fv3gfs.wrapper.get_state(names=OVERRIDES_FOR_SURFACE_RADIATIVE_FLUXES)
-    replace_state = deepcopy(old_state)
-    for name, quantity in replace_state.items():
-        quantity.view[:] = np.random.uniform(size=quantity.extent)
-    fv3gfs.wrapper.set_state(replace_state)
-    return replace_state
 
 
 def get_state_single_variable(name):
@@ -64,7 +54,7 @@ class OverridingSurfaceRadiativeFluxTests(unittest.TestCase):
         # Restore state to original checkpoint; modify the radiative fluxes;
         # step the model again.
         fv3gfs.wrapper.set_state(checkpoint_state)
-        override_surface_radiative_fluxes_with_random_values()
+        replace_state_with_random_values(OVERRIDES_FOR_SURFACE_RADIATIVE_FLUXES)
         fv3gfs.wrapper.step()
         temperature_with_random_override = get_state_single_variable("air_temperature")
 
@@ -74,7 +64,9 @@ class OverridingSurfaceRadiativeFluxTests(unittest.TestCase):
         )
 
     def test_overriding_fluxes_are_propagated_to_diagnostics(self):
-        replace_state = override_surface_radiative_fluxes_with_random_values()
+        replace_state = replace_state_with_random_values(
+            OVERRIDES_FOR_SURFACE_RADIATIVE_FLUXES
+        )
 
         # We need to step the model to fill the diagnostics buckets.
         fv3gfs.wrapper.step()

--- a/tests/test_overrides_for_surface_radiative_fluxes.py
+++ b/tests/test_overrides_for_surface_radiative_fluxes.py
@@ -5,7 +5,7 @@ import numpy as np
 import fv3gfs.wrapper
 import fv3gfs.util
 from mpi4py import MPI
-from util import get_default_config, main, replace_state_with_random_values
+from util import get_default_config, get_state_single_variable, main, replace_state_with_random_values
 
 
 test_dir = os.path.dirname(os.path.abspath(__file__))
@@ -14,10 +14,6 @@ test_dir = os.path.dirname(os.path.abspath(__file__))
     DOWNWARD_SHORTWAVE,
     NET_SHORTWAVE,
 ) = OVERRIDES_FOR_SURFACE_RADIATIVE_FLUXES
-
-
-def get_state_single_variable(name):
-    return fv3gfs.wrapper.get_state([name])[name].view[:]
 
 
 class OverridingSurfaceRadiativeFluxTests(unittest.TestCase):

--- a/tests/test_overrides_for_surface_radiative_fluxes.py
+++ b/tests/test_overrides_for_surface_radiative_fluxes.py
@@ -5,7 +5,12 @@ import numpy as np
 import fv3gfs.wrapper
 import fv3gfs.util
 from mpi4py import MPI
-from util import get_default_config, get_state_single_variable, main, replace_state_with_random_values
+from util import (
+    get_default_config,
+    get_state_single_variable,
+    main,
+    replace_state_with_random_values,
+)
 
 
 test_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/test_set_ocean_surface_temperature.py
+++ b/tests/test_set_ocean_surface_temperature.py
@@ -1,0 +1,74 @@
+import unittest
+import os
+from copy import deepcopy
+import numpy as np
+import fv3gfs.wrapper
+import fv3gfs.util
+from mpi4py import MPI
+from util import get_default_config, main
+
+
+test_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def prescribe_sea_surface_temperature_with_random_values():
+    old_state = fv3gfs.wrapper.get_state(names=["ocean_surface_temperature"])
+    replace_state = deepcopy(old_state)
+    for name, quantity in replace_state.items():
+        quantity.view[:] = np.random.uniform(size=quantity.extent)
+    fv3gfs.wrapper.set_state(replace_state)
+    return replace_state
+
+
+def get_state_single_variable(name):
+    return fv3gfs.wrapper.get_state([name])[name].view[:]
+
+
+class PrescribeSSTTests(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(PrescribeSSTTests, self).__init__(*args, **kwargs)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        MPI.COMM_WORLD.barrier()
+
+    def test_resetting_to_checkpoint_allows_for_exact_restart(self):
+        checkpoint_state = fv3gfs.wrapper.get_state(fv3gfs.wrapper.get_restart_names())
+
+        # Run the model forward a timestep and save the temperature.
+        fv3gfs.wrapper.step()
+        expected = get_state_single_variable("air_temperature")
+
+        # Restore state to original checkpoint; step the model forward again.
+        # Check that the temperature is identical as after the first time we
+        # took a step.
+        fv3gfs.wrapper.set_state(checkpoint_state)
+        fv3gfs.wrapper.step()
+        result = get_state_single_variable("air_temperature")
+        np.testing.assert_equal(result, expected)
+
+    def test_prescribing_sst_changes_model_state(self):
+        checkpoint_state = fv3gfs.wrapper.get_state(fv3gfs.wrapper.get_restart_names())
+
+        fv3gfs.wrapper.step()
+        air_temperature_from_default_ocean_temperature = get_state_single_variable("air_temperature")
+
+        # Restore state to original checkpoint; modify the SST;
+        # step the model again.
+        fv3gfs.wrapper.set_state(checkpoint_state)
+        prescribe_sea_surface_temperature_with_random_values()
+        fv3gfs.wrapper.step()
+        air_temperature_from_prescribed_ocean_temperature = get_state_single_variable("air_temperature")
+
+        # If the SST modification were working properly, we would expect these
+        # states to differ.
+        assert not np.array_equal(
+            air_temperature_from_default_ocean_temperature, air_temperature_from_prescribed_ocean_temperature
+        )
+
+
+if __name__ == "__main__":
+    config = get_default_config()
+    main(test_dir, config)

--- a/tests/test_set_ocean_surface_temperature.py
+++ b/tests/test_set_ocean_surface_temperature.py
@@ -15,9 +15,9 @@ from util import (
 test_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-def select_ocean_values(field):
+def select_ocean_values(*fields):
     is_ocean = np.isclose(get_state_single_variable("land_sea_mask"), 0.0)
-    return field[is_ocean]
+    return (field[is_ocean] for field in fields)
 
 
 class PrescribeSSTTests(unittest.TestCase):
@@ -62,8 +62,7 @@ class PrescribeSSTTests(unittest.TestCase):
             "tsfc", module_name="gfs_sfc"
         ).view[:]
 
-        result = select_ocean_values(surface_temperature_diagnostic)
-        expected = select_ocean_values(prescribed_sst)
+        result, expected = select_ocean_values(surface_temperature_diagnostic, prescribed_sst)
         np.testing.assert_allclose(result, expected)
 
 

--- a/tests/test_set_ocean_surface_temperature.py
+++ b/tests/test_set_ocean_surface_temperature.py
@@ -48,7 +48,7 @@ class PrescribeSSTTests(unittest.TestCase):
         )
 
         # We expect these states to differ.
-        assert not np.array_equal(
+        assert not np.assert_allclose(
             air_temperature_from_default_ocean_temperature,
             air_temperature_from_prescribed_ocean_temperature,
         )
@@ -69,5 +69,5 @@ class PrescribeSSTTests(unittest.TestCase):
 
 if __name__ == "__main__":
     config = get_default_config()
-    config["namelist"]["gfs_physics_nml"]["override_ocean_surface_temperature"] = True
+    config["namelist"]["gfs_physics_nml"]["use_climatological_sst"] = False
     main(test_dir, config)

--- a/tests/test_set_ocean_surface_temperature.py
+++ b/tests/test_set_ocean_surface_temperature.py
@@ -62,7 +62,9 @@ class PrescribeSSTTests(unittest.TestCase):
             "tsfc", module_name="gfs_sfc"
         ).view[:]
 
-        result, expected = select_ocean_values(surface_temperature_diagnostic, prescribed_sst)
+        result, expected = select_ocean_values(
+            surface_temperature_diagnostic, prescribed_sst
+        )
         np.testing.assert_allclose(result, expected)
 
 

--- a/tests/test_set_ocean_surface_temperature.py
+++ b/tests/test_set_ocean_surface_temperature.py
@@ -48,7 +48,7 @@ class PrescribeSSTTests(unittest.TestCase):
         )
 
         # We expect these states to differ.
-        assert not np.assert_allclose(
+        assert not np.isclose(
             air_temperature_from_default_ocean_temperature,
             air_temperature_from_prescribed_ocean_temperature,
         )

--- a/tests/test_set_ocean_surface_temperature.py
+++ b/tests/test_set_ocean_surface_temperature.py
@@ -51,8 +51,7 @@ class PrescribeSSTTests(unittest.TestCase):
             "air_temperature"
         )
 
-        # If the SST modification were working properly, we would expect these
-        # states to differ.
+        # We expect these states to differ.
         assert not np.array_equal(
             air_temperature_from_default_ocean_temperature,
             air_temperature_from_prescribed_ocean_temperature,

--- a/tests/test_set_ocean_surface_temperature.py
+++ b/tests/test_set_ocean_surface_temperature.py
@@ -48,7 +48,7 @@ class PrescribeSSTTests(unittest.TestCase):
         )
 
         # We expect these states to differ.
-        assert not np.isclose(
+        assert not np.allclose(
             air_temperature_from_default_ocean_temperature,
             air_temperature_from_prescribed_ocean_temperature,
         )

--- a/tests/test_set_ocean_surface_temperature.py
+++ b/tests/test_set_ocean_surface_temperature.py
@@ -34,21 +34,6 @@ class PrescribeSSTTests(unittest.TestCase):
     def tearDown(self):
         MPI.COMM_WORLD.barrier()
 
-    def test_resetting_to_checkpoint_allows_for_exact_restart(self):
-        checkpoint_state = fv3gfs.wrapper.get_state(fv3gfs.wrapper.get_restart_names())
-
-        # Run the model forward a timestep and save the temperature.
-        fv3gfs.wrapper.step()
-        expected = get_state_single_variable("air_temperature")
-
-        # Restore state to original checkpoint; step the model forward again.
-        # Check that the temperature is identical as after the first time we
-        # took a step.
-        fv3gfs.wrapper.set_state(checkpoint_state)
-        fv3gfs.wrapper.step()
-        result = get_state_single_variable("air_temperature")
-        np.testing.assert_equal(result, expected)
-
     def test_prescribing_sst_changes_model_state(self):
         checkpoint_state = fv3gfs.wrapper.get_state(fv3gfs.wrapper.get_restart_names())
 
@@ -76,4 +61,5 @@ class PrescribeSSTTests(unittest.TestCase):
 
 if __name__ == "__main__":
     config = get_default_config()
+    config["namelist"]["gfs_physics_nml"]["prescribe_sst_from_wrapper"] = True
     main(test_dir, config)

--- a/tests/test_set_ocean_surface_temperature.py
+++ b/tests/test_set_ocean_surface_temperature.py
@@ -53,19 +53,24 @@ class PrescribeSSTTests(unittest.TestCase):
         checkpoint_state = fv3gfs.wrapper.get_state(fv3gfs.wrapper.get_restart_names())
 
         fv3gfs.wrapper.step()
-        air_temperature_from_default_ocean_temperature = get_state_single_variable("air_temperature")
+        air_temperature_from_default_ocean_temperature = get_state_single_variable(
+            "air_temperature"
+        )
 
         # Restore state to original checkpoint; modify the SST;
         # step the model again.
         fv3gfs.wrapper.set_state(checkpoint_state)
         prescribe_sea_surface_temperature_with_random_values()
         fv3gfs.wrapper.step()
-        air_temperature_from_prescribed_ocean_temperature = get_state_single_variable("air_temperature")
+        air_temperature_from_prescribed_ocean_temperature = get_state_single_variable(
+            "air_temperature"
+        )
 
         # If the SST modification were working properly, we would expect these
         # states to differ.
         assert not np.array_equal(
-            air_temperature_from_default_ocean_temperature, air_temperature_from_prescribed_ocean_temperature
+            air_temperature_from_default_ocean_temperature,
+            air_temperature_from_prescribed_ocean_temperature,
         )
 
 

--- a/tests/test_set_ocean_surface_temperature.py
+++ b/tests/test_set_ocean_surface_temperature.py
@@ -4,14 +4,10 @@ import numpy as np
 import fv3gfs.wrapper
 import fv3gfs.util
 from mpi4py import MPI
-from util import get_default_config, main, replace_state_with_random_values
+from util import get_default_config, get_state_single_variable, main, replace_state_with_random_values
 
 
 test_dir = os.path.dirname(os.path.abspath(__file__))
-
-
-def get_state_single_variable(name):
-    return fv3gfs.wrapper.get_state([name])[name].view[:]
 
 
 def mask_non_ocean_values(field):

--- a/tests/test_set_ocean_surface_temperature.py
+++ b/tests/test_set_ocean_surface_temperature.py
@@ -4,7 +4,12 @@ import numpy as np
 import fv3gfs.wrapper
 import fv3gfs.util
 from mpi4py import MPI
-from util import get_default_config, get_state_single_variable, main, replace_state_with_random_values
+from util import (
+    get_default_config,
+    get_state_single_variable,
+    main,
+    replace_state_with_random_values,
+)
 
 
 test_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/test_setters.py
+++ b/tests/test_setters.py
@@ -11,7 +11,13 @@ from fv3gfs.wrapper._properties import (
 )
 import fv3gfs.util
 from mpi4py import MPI
-from util import get_current_config, get_default_config, generate_data_dict, main
+from util import (
+    get_current_config,
+    get_default_config,
+    generate_data_dict,
+    main,
+    replace_state_with_random_values,
+)
 
 
 test_dir = os.path.dirname(os.path.abspath(__file__))
@@ -128,12 +134,7 @@ class SetterTests(unittest.TestCase):
         self._set_names_one_at_a_time_helper(name_list)
 
     def _set_all_names_at_once_helper(self, name_list):
-        old_state = fv3gfs.wrapper.get_state(names=name_list)
-        self._check_gotten_state(old_state, name_list)
-        replace_state = deepcopy(old_state)
-        for name, quantity in replace_state.items():
-            quantity.view[:] = np.random.uniform(size=quantity.extent)
-        fv3gfs.wrapper.set_state(replace_state)
+        replace_state = replace_state_with_random_values(name_list)
         new_state = fv3gfs.wrapper.get_state(names=name_list)
         self._check_gotten_state(new_state, name_list)
         for name, new_quantity in new_state.items():

--- a/tests/util.py
+++ b/tests/util.py
@@ -124,3 +124,7 @@ def replace_state_with_random_values(names):
         quantity.view[:] = np.random.uniform(size=quantity.extent)
     fv3gfs.wrapper.set_state(replace_state)
     return replace_state
+
+
+def get_state_single_variable(name):
+    return fv3gfs.wrapper.get_state([name])[name].view[:]

--- a/tests/util.py
+++ b/tests/util.py
@@ -7,8 +7,10 @@ import subprocess
 import yaml
 import unittest
 import shutil
+import numpy as np
 import fv3config
 import fv3gfs.wrapper
+from copy import deepcopy
 from mpi4py import MPI
 
 libc = ctypes.CDLL(None)
@@ -113,3 +115,12 @@ def get_current_config():
 
 def generate_data_dict(properties):
     return {entry["name"]: entry for entry in properties}
+
+
+def replace_state_with_random_values(names):
+    old_state = fv3gfs.wrapper.get_state(names=names)
+    replace_state = deepcopy(old_state)
+    for name, quantity in replace_state.items():
+        quantity.view[:] = np.random.uniform(size=quantity.extent)
+    fv3gfs.wrapper.set_state(replace_state)
+    return replace_state


### PR DESCRIPTION
This PR adds a test confirming that with the use of the namelist flag added in VulcanClimateModeling/fv3gfs-fortran#173, setting the `"ocean_surface_temperature"` modifies the evolution of the model's prognostic variables (e.g. air temperature).  

In between VulcanClimateModeling/fv3gfs-fortran#173 and VulcanClimateModeling/fv3gfs-fortran#93, this functionality was broken (see [the failing test](https://circleci.com/gh/VulcanClimateModeling/fv3gfs-wrapper/3102?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) associated with 5a6febb of this PR).   In other words, since VulcanClimateModeling/fv3gfs-fortran#93, `Sfcprop%tsfco` in the fortran model was modified within the physics driver prior to being used by any physics scheme; therefore when we set it via Python, it was immediately set to something else in the fortran before it could have any impact.  The namelist parameter toggles the behavior back to what it was before VulcanClimateModeling/fv3gfs-fortran#93, allowing us to prescribe the SST.