### PR TITLE
Add setter for surface_precipitation_rate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     - image: circleci/python:3.7
     steps:
       - checkout
-      - run: sudo pip3 install black==19.10b0 flake8==3.7.8
+      - run: sudo pip3 install black==19.10b0 flake8==3.7.8 click==8.0.4
       - run: make lint
 
   build_default:

--- a/templates/_wrapper.pyx
+++ b/templates/_wrapper.pyx
@@ -147,10 +147,14 @@ def set_state(state):
         if name == 'time':
             set_time(state[name])
         elif name == SURFACE_PRECIPITATION_RATE:
-            quantity = quantity.transpose([pace.util.Y_DIMS, pace.util.X_DIMS])
             get_physics_timestep_subroutine(&dt_physics)
-            quantity.view[:] *= dt_physics / MM_PER_M
-            set_2d_quantity("total_precipitation", np.ascontiguousarray(quantity.view[:]))
+            quantity = quantity.transpose([pace.util.Y_DIMS, pace.util.X_DIMS])
+            total_precipitation = pace.util.Quantity(
+                quantity.view[:] * dt_physics / MM_PER_M,
+                [pace.util.Y_DIMS, pace.util.X_DIMS],
+                units='m',
+            )
+            set_2d_quantity("total_precipitation", np.ascontiguousarray(total_precipitation.view[:]))
         elif len(quantity.dims) == 3:
             quantity = quantity.transpose(
                 DIM_NAMES.get(

--- a/templates/_wrapper.pyx
+++ b/templates/_wrapper.pyx
@@ -140,11 +140,17 @@ def set_state(state):
     cdef REAL_t[:, :, ::1] input_value_3d
     cdef REAL_t[:, ::1] input_value_2d
     cdef REAL_t[::1] input_value_1d
+    cdef int dt_physics
     tracer_metadata = get_tracer_metadata()
     cdef set processed_names_set = set()
     for name, quantity in state.items():
         if name == 'time':
             set_time(state[name])
+        elif name == SURFACE_PRECIPITATION_RATE:
+            quantity = quantity.transpose([pace.util.Y_DIMS, pace.util.X_DIMS])
+            get_physics_timestep_subroutine(&dt_physics)
+            quantity.view[:] *= dt_physics / MM_PER_M
+            set_2d_quantity("total_precipitation", np.ascontiguousarray(quantity.view[:]))
         elif len(quantity.dims) == 3:
             quantity = quantity.transpose(
                 DIM_NAMES.get(

--- a/tests/test_setters.py
+++ b/tests/test_setters.py
@@ -197,6 +197,21 @@ class SetterTests(unittest.TestCase):
             with self.subTest(name):
                 self._set_unallocated_override_for_radiative_surface_flux(name)
 
+    def test_set_surface_precipitation_rate(self):
+        """Special test since this quantity is not in physics_properties.json file"""
+        state = fv3gfs.wrapper.get_state(
+            names=["total_precipitation", "surface_precipitation_rate"]
+        )
+        total_precip_old = state["total_precipitation"]
+        precip_rate_new = state["surface_precipitation_rate"]
+        precip_rate_new.view[:] = 2 * precip_rate_new.view[:]
+        fv3gfs.wrapper.set_state({"surface_precipitation_rate": precip_rate_new})
+        state_new = fv3gfs.wrapper.get_state(["total_precipitation"])
+        total_precip_new = state_new["total_precipitation"]
+        np.testing.assert_allclose(
+            2 * total_precip_old.view[:], total_precip_new.view[:]
+        )
+
 
 def get_override_surface_radiative_fluxes():
     """A crude way of parameterizing the setter tests for different values of

--- a/tests/test_setters.py
+++ b/tests/test_setters.py
@@ -205,7 +205,9 @@ class SetterTests(unittest.TestCase):
         total_precip_old = state["total_precipitation"]
         precip_rate_new = state["surface_precipitation_rate"]
         precip_rate_new.view[:] = 2 * precip_rate_new.view[:]
+        precip_rate_new_copy = deepcopy(precip_rate_new)
         fv3gfs.wrapper.set_state({"surface_precipitation_rate": precip_rate_new})
+        np.testing.assert_equal(precip_rate_new.view[:], precip_rate_new_copy.view[:])
         state_new = fv3gfs.wrapper.get_state(["total_precipitation"])
         total_precip_new = state_new["total_precipitation"]
         np.testing.assert_allclose(


### PR DESCRIPTION
It is useful to be able to directly set the `surface_precipitation_rate`, which is equal to `total_precipitation * 1000 / dt_phys`. Currently we only have a getter for this quantity.